### PR TITLE
Fix dimension order detection in validate functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyturbo_sf"
-version = "1.0.6"
+version = "1.0.7"
 description = "Python Turbulence Unleashed: Rapid Binning Operator"
 readme = "README.md"
 authors = [

--- a/src/pyturbo_sf/__init__.py
+++ b/src/pyturbo_sf/__init__.py
@@ -47,7 +47,7 @@ from . import bootstrapping_tools
 from . import isotropy_tools
 from . import bessel_tools
 
-__version__ = "1.0.6"
+__version__ = "1.0.7"
 
 __all__ = [
     # Main functions

--- a/src/pyturbo_sf/core.py
+++ b/src/pyturbo_sf/core.py
@@ -180,8 +180,9 @@ def validate_dataset_1d(ds):
     ValueError
         If the dataset doesn't have exactly one dimension
     """
-    # Get all dimensions
-    dims = list(ds.dims)
+    # Get dimensions from a data variable to get actual order
+    first_var = list(ds.data_vars)[0]
+    dims = list(ds[first_var].dims)
     
     # Verify there's only one dimension
     if len(dims) != 1:
@@ -226,8 +227,9 @@ def validate_dataset_2d(ds):
     ValueError
         If dataset doesn't have exactly 2 dimensions or dimensions are incompatible
     """
-    # Get dimensions
-    dims = list(ds.dims)
+    # Get dimensions from a data variable to get actual order
+    first_var = list(ds.data_vars)[0]
+    dims = list(ds[first_var].dims)
     
     # Check for exactly 2 dimensions
     if len(dims) != 2:
@@ -257,11 +259,11 @@ def validate_dataset_2d(ds):
     if reversed_pair in expected_pairs:
         # Transpose to correct order
         transposed_ds = ds.transpose(dims[1], dims[0])
-        transposed_dims = list(transposed_ds.dims)
+        transposed_dims = [dims[1], dims[0]]  # Use requested order directly
         print(f"Transposed dimensions from {dims} to {transposed_dims}")
         
         # Update time_dims to match new order
-        time_dims = {dim: time_dims[dims[i]] for i, dim in enumerate(transposed_dims)}
+        time_dims = {dim: time_dims[dim] for dim in transposed_dims}
         
         # Print time dimension information
         for dim, is_time in time_dims.items():
@@ -312,8 +314,9 @@ def validate_dataset_3d(ds):
     ValueError
         If dataset doesn't have exactly 3 dimensions or dimensions are incompatible
     """
-    # Get dimensions
-    dims = list(ds.dims)
+    # Get dimensions from a data variable to get actual order
+    first_var = list(ds.data_vars)[0]
+    dims = list(ds[first_var].dims)
     
     # Check for exactly 3 dimensions
     if len(dims) != 3:
@@ -344,11 +347,11 @@ def validate_dataset_3d(ds):
     
     # If the dimensions are not in the right order, transpose to correct order
     transposed_ds = ds.transpose(*expected_order)
-    transposed_dims = list(transposed_ds.dims)
+    transposed_dims = expected_order  # Use requested order directly
     print(f"Transposed dimensions to {transposed_dims}")
     
     # Update time_dims to match new order
-    time_dims = {dim: time_dims[dims[i]] for i, dim in enumerate(transposed_dims)}
+    time_dims = {dim: time_dims[dim] for dim in transposed_dims}
     
     return transposed_dims, dict(transposed_ds.sizes), transposed_ds, time_dims
     


### PR DESCRIPTION
Fixed bug where list(ds.dims) returned unreliable dimension order for xarray Datasets. Now using list(ds[first_var].dims) to get actual order from data variables.